### PR TITLE
Add preliminary VS Code highlighting support

### DIFF
--- a/etc/vscode/README.md
+++ b/etc/vscode/README.md
@@ -1,0 +1,5 @@
+# pris README
+
+This extension adds syntax highlighting support for the [pris](https://ruuda.github.io/pris) language to VS Code.
+
+To install it, create a directory `extension/pris` in your vscode installation, fill it with the content of the pris `etc/vscode` folder and reload VS Code.

--- a/etc/vscode/language-configuration.json
+++ b/etc/vscode/language-configuration.json
@@ -1,0 +1,25 @@
+{
+    "comments": {
+        // symbol used for single line comment. Remove this entry if your language does not support line comments
+        "lineComment": "//"
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ],
+    // symbols that that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""]
+    ]
+}

--- a/etc/vscode/package.json
+++ b/etc/vscode/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "pris",
+    "displayName": "pris",
+    "description": "pris language support",
+    "version": "0.0.1",
+    "publisher": "pris",
+    "engines": {
+        "vscode": "^1.22.0"
+    },
+    "categories": [
+        "Languages"
+    ],
+    "contributes": {
+        "languages": [{
+            "id": "pris",
+            "aliases": ["pris", "pris"],
+            "extensions": [".pris"],
+            "configuration": "./language-configuration.json"
+        }],
+        "grammars": [{
+            "language": "pris",
+            "scopeName": "source.pris",
+            "path": "./syntaxes/pris.tmLanguage.json"
+        }]
+    }
+}

--- a/etc/vscode/syntaxes/pris.tmLanguage.json
+++ b/etc/vscode/syntaxes/pris.tmLanguage.json
@@ -1,0 +1,54 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "pris",
+	"patterns": [
+		{
+			"include": "#keywords"
+		},
+		{
+			"include": "#strings"
+		},
+		{
+			"include": "#comments"
+		},
+		{
+			"include": "#constants"
+		}
+	],
+	"repository": {
+		"keywords": {
+			"patterns": [{
+				"name": "keyword.control.pris",
+				"match": "\\b(at|function|import|put|return)\\b"
+			}]
+		},
+		"strings": {
+			"name": "string.quoted.double.pris",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.pris",
+					"match": "\\\\."
+				}
+			]
+		},
+		"comments": {
+			"patterns": [{
+				"name": "comment",
+				"match": "//.*"
+			}]
+		},
+		"constants": {
+			"patterns": [{
+				"name": "constant.numeric.hex",
+				"match": "#[0-9a-fA-F]+"
+			},
+			{
+				"name": "constant.numeric",
+				"match": "(\\d+\\.)?\\d+(w|h|em|pt)?"	
+			}]
+		}
+	},
+	"scopeName": "source.pris"
+}


### PR DESCRIPTION
Hello!

As discussed in #7, here is an attempt to add highlighting of the pris syntax in VS Code. I did not modify some of the files created by the [extension generator](https://code.visualstudio.com/docs/extensions/yocode) for the moment.

Thanks a lot for making pris!
Best regards,
Thomas