### PR TITLE
Add support for lists and drawing solid polygons

### DIFF
--- a/docs/reference/fill_polygon.md
+++ b/docs/reference/fill_polygon.md
@@ -1,0 +1,12 @@
+# fill_polygon
+
+    fill_polygon(vertices: list of coord) -> frame
+
+Draw a solid polygon.
+
+The fill color is taken from the `color` variable.
+
+For example, drawing a rectangle with 2em sides:
+
+    vertices = [(-1em, 1em); (1em, 1em); (1em, -1em); (-1em, -1em)]
+    fill_polygon(vertices)

--- a/etc/pris.y
+++ b/etc/pris.y
@@ -87,6 +87,7 @@ coord: '(' expr ',' expr ')';
 fn_call
   : term '(' ')'
   | term '(' fn_call_args ')'
+  | term '(' fn_call_args ',' ')'
   ;
 
 fn_call_args: expr | fn_call_args ',' expr;
@@ -94,6 +95,7 @@ fn_call_args: expr | fn_call_args ',' expr;
 fn_def
   : "function" '(' ')'
   | "function" '(' fn_def_args ')'
+  | "function" '(' fn_def_args ',' ')'
   ;
 
 fn_def_args: IDENT | fn_def_args ',' IDENT;

--- a/etc/pris.y
+++ b/etc/pris.y
@@ -72,6 +72,7 @@ term
   | coord
   | fn_def
   | block
+  | list
   | '(' expr ')'
   ;
 
@@ -96,6 +97,14 @@ fn_def
   ;
 
 fn_def_args: IDENT | fn_def_args ',' IDENT;
+
+list
+  : '[' ']'
+  | '[' list_elems ']'
+  | '[' list_elems ';' ']' /* Allow but do not require a trailing semicolon. */
+  ;
+
+list_elems : expr | list_elems ';' expr;
 
 block
   : '{' '}'

--- a/examples/list.pris
+++ b/examples/list.pris
@@ -1,0 +1,20 @@
+// Lists are wrapped in []. Elements are terminated with a semicolon.
+xs = [1; 2; 3;]
+
+lines =
+[
+  "Hello";
+  "World";
+]
+
+// Elements are expressions.
+mid = (0.5w, 0.5h)
+ys =
+[
+  (1em, 1em) + mid;
+  (2em, 2em) + mid;
+]
+
+{
+  put t("Foo") at mid
+}

--- a/examples/list.pris
+++ b/examples/list.pris
@@ -16,5 +16,6 @@ ys =
 ]
 
 {
+  // TODO: Add example that uses a list.
   put t("Foo") at mid
 }

--- a/examples/polygon.pris
+++ b/examples/polygon.pris
@@ -1,0 +1,14 @@
+{
+  font_size = 0.1h
+
+  vertices =
+  [
+    (-1em,  1em);
+    ( 1em,  1em);
+    ( 1em, -1em);
+    ( 0em, -2em);
+    (-1em, -1em);
+  ]
+
+  put fill_polygon(vertices) at (0.5w, 0.5h)
+}

--- a/examples/polygon.pris
+++ b/examples/polygon.pris
@@ -1,5 +1,7 @@
 {
   font_size = 0.1h
+  background_color = #575D90
+  color = #E6F14A
 
   vertices =
   [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
     - at: reference/at.md
     - canvas_size: reference/canvas_size.md
     - fill_circle: reference/fill_circle.md
+    - fill_polygon: reference/fill_polygon.md
     - fill_rectangle: reference/fill_rectangle.md
     - fit: reference/fit.md
     - glyph: reference/glyph.md

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -25,6 +25,9 @@ pub struct Import<'a>(pub Idents<'a>);
 pub struct Idents<'a>(pub Vec<&'a str>);
 
 #[derive(PartialEq)]
+pub struct List<'a>(pub Vec<Term<'a>>);
+
+#[derive(PartialEq)]
 pub struct Assign<'a>(pub &'a str, pub Term<'a>);
 
 #[derive(PartialEq)]
@@ -39,6 +42,7 @@ pub enum Term<'a> {
     FnCall(Box<FnCall<'a>>),
     FnDef(FnDef<'a>),
     Block(Block<'a>),
+    List(List<'a>),
 }
 
 impl<'a> Term<'a> {
@@ -191,6 +195,7 @@ impl<'a> Print for Term<'a> {
             Term::FnCall(ref fc) => f.print(fc),
             Term::FnDef(ref fdf) => f.print(fdf),
             Term::Block(ref blk) => f.print(blk),
+            Term::List(ref list) => f.print(list),
         }
     }
 }
@@ -316,6 +321,23 @@ impl<'a> Print for Block<'a> {
         }
         f.indent_less();
         f.println("}");
+    }
+}
+
+impl<'a> Print for List<'a> {
+    fn print(&self, f: &mut Formatter) {
+        if self.0.len() == 0 {
+            f.print("[]");
+        } else {
+            f.print("[\n");
+            f.indent_more();
+            for element in &self.0 {
+                f.print(element);
+                f.print(";\n");
+            }
+            f.indent_less();
+            f.print("]");
+        }
     }
 }
 

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -181,6 +181,31 @@ pub fn line<'i, 'a>(interpreter: &mut ExprInterpreter<'i, 'a>,
     Ok(Val::Frame(Rc::new(frame)))
 }
 
+fn fill_polygon_impl<'i, 'a>(
+    interpreter: &mut ExprInterpreter<'i, 'a>,
+    vertices: Vec<Vec2>,
+    kind: PolygonKind,
+) -> Result<Frame<'a>> {
+    // TODO: Better idents type for non-ast use?
+    let color = interpreter.env.lookup_color(&Idents(vec![names::color]))?;
+
+    let mut frame = Frame::new();
+
+    for v in &vertices {
+        frame.union_bounding_box(&BoundingBox::empty().offset(*v));
+    }
+
+    let polygon = FillPolygon {
+        color: color,
+        vertices: vertices,
+        kind: kind,
+    };
+
+    frame.place_element_on_last_subframe(Vec2::zero(), Element::FillPolygon(polygon));
+
+    Ok(frame)
+}
+
 pub fn fill_circle<'i, 'a>(interpreter: &mut ExprInterpreter<'i, 'a>,
                            mut args: Vec<Val<'a>>)
                            -> Result<Val<'a>> {
@@ -194,31 +219,24 @@ pub fn fill_circle<'i, 'a>(interpreter: &mut ExprInterpreter<'i, 'a>,
     let c = 0.551915024494 * r;
     let z = 0.0;
 
-    let circle = FillPolygon {
-        // TODO: Better idents type for non-ast use?
-        color: interpreter.env.lookup_color(&Idents(vec![names::color]))?,
-        vertices: vec![
-            Vec2::new( r,  z), // Right
-            Vec2::new( r, -c),
-            Vec2::new( c, -r),
-            Vec2::new( z, -r), // Top
-            Vec2::new(-c, -r),
-            Vec2::new(-r, -c),
-            Vec2::new(-r,  z), // Left
-            Vec2::new(-r,  c),
-            Vec2::new(-c,  r),
-            Vec2::new( z,  r), // Bottom
-            Vec2::new( c,  r),
-            Vec2::new( r,  c),
-        ],
-        kind: PolygonKind::Curves,
-    };
+    let vertices = vec![
+        Vec2::new( r,  z), // Right
+        Vec2::new( r, -c),
+        Vec2::new( c, -r),
+        Vec2::new( z, -r), // Top
+        Vec2::new(-c, -r),
+        Vec2::new(-r, -c),
+        Vec2::new(-r,  z), // Left
+        Vec2::new(-r,  c),
+        Vec2::new(-c,  r),
+        Vec2::new( z,  r), // Bottom
+        Vec2::new( c,  r),
+        Vec2::new( r,  c),
+    ];
 
-    let mut frame = Frame::new();
-    frame.place_element_on_last_subframe(Vec2::zero(), Element::FillPolygon(circle));
+    let mut frame = fill_polygon_impl(interpreter, vertices, PolygonKind::Curves)?;
+
     frame.set_anchor(Vec2::zero());
-    let rr = Vec2::new(r, r);
-    frame.union_bounding_box(&BoundingBox::new(-rr, rr * 2.0));
 
     Ok(Val::Frame(Rc::new(frame)))
 }
@@ -232,23 +250,16 @@ pub fn fill_rectangle<'i, 'a>(interpreter: &mut ExprInterpreter<'i, 'a>,
         _ => unreachable!(),
     };
 
-    let rect = FillPolygon {
-        // TODO: Better idents type for non-ast use?
-        color: interpreter.env.lookup_color(&Idents(vec![names::color]))?,
-        vertices: vec![
-            Vec2::zero(),
-            Vec2::new(0.0, h),
-            Vec2::new(w, h),
-            Vec2::new(w, 0.0),
-        ],
-        kind: PolygonKind::Lines,
-    };
+    let vertices = vec![
+        Vec2::zero(),
+        Vec2::new(0.0, h),
+        Vec2::new(w, h),
+        Vec2::new(w, 0.0),
+    ];
 
-    let mut frame = Frame::new();
-    frame.place_element_on_last_subframe(Vec2::zero(), Element::FillPolygon(rect));
+    let mut frame = fill_polygon_impl(interpreter, vertices, PolygonKind::Lines)?;
+
     frame.set_anchor(Vec2::new(w, h));
-    // TODO: Make bounding box take Vec2.
-    frame.union_bounding_box(&BoundingBox::sized(w, h));
 
     Ok(Val::Frame(Rc::new(frame)))
 }
@@ -263,17 +274,12 @@ pub fn fill_polygon<'i, 'a>(interpreter: &mut ExprInterpreter<'i, 'a>,
     };
 
     let mut vertices = Vec::with_capacity(coords.len());
-    let mut bounding_box = BoundingBox::empty();
-    let mut anchor = Vec2::zero();
 
     // Collect the vertices, ensuring that they have the right type.
     for vertex in &coords {
         match vertex {
             &Val::Coord(x, y, 1) => {
                 let v = Vec2::new(x, y);
-                let bb = BoundingBox::empty().offset(v);
-                bounding_box = bounding_box.union(&bb);
-                anchor = v;
                 vertices.push(v);
             }
             not_coord_of_len => {
@@ -285,17 +291,10 @@ pub fn fill_polygon<'i, 'a>(interpreter: &mut ExprInterpreter<'i, 'a>,
         }
     }
 
-    // TODO: Deduplicate env logic for different shapes.
-    let rect = FillPolygon {
-        color: interpreter.env.lookup_color(&Idents(vec![names::color]))?,
-        vertices: vertices,
-        kind: PolygonKind::Lines,
-    };
-
-    let mut frame = Frame::new();
-    frame.place_element_on_last_subframe(Vec2::zero(), Element::FillPolygon(rect));
+    // TODO: Demand at least two coords.
+    let anchor = vertices.last().cloned().unwrap_or(Vec2::zero());
+    let mut frame = fill_polygon_impl(interpreter, vertices, PolygonKind::Lines)?;
     frame.set_anchor(anchor);
-    frame.union_bounding_box(&bounding_box);
 
     Ok(Val::Frame(Rc::new(frame)))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -179,6 +179,21 @@ impl Error {
         Error::Type(type_error)
     }
 
+    pub fn list_type(expected_element_type: ValType, actual_element_type: ValType) -> Error {
+        let mut f = Formatter::new();
+        f.print("Encountered elements of type '");
+        f.print(expected_element_type);
+        f.print("' as well as '");
+        f.print(actual_element_type);
+        f.print("' in one list, but all elements must have the same type.");
+        let type_error = TypeError {
+            expected: expected_element_type,
+            actual: actual_element_type,
+            message: f.into_string(),
+        };
+        Error::Type(type_error)
+    }
+
     pub fn value(message: String) -> Error {
         let err = ValueError {
             message: message,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -38,6 +38,7 @@ impl<'i, 'a> ExprInterpreter<'i, 'a> {
             Term::FnCall(ref f) => self.eval_call(f),
             Term::FnDef(ref fd) => Ok(Val::FnExtrin(fd)),
             Term::Block(ref bk) => self.eval_block(bk),
+            Term::List(ref _lst) => panic!("TODO: Implement lists."),
         }
     }
 

--- a/src/names.rs
+++ b/src/names.rs
@@ -14,6 +14,7 @@ pub const at: &'static str = "at";
 pub const canvas_size: &'static str = "canvas_size";
 pub const color: &'static str = "color";
 pub const fill_circle: &'static str = "fill_circle";
+pub const fill_polygon: &'static str = "fill_polygon";
 pub const fill_rectangle: &'static str = "fill_rectangle";
 pub const fit: &'static str = "fit";
 pub const font_family: &'static str = "font_family";

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1136,4 +1136,63 @@ mod test {
         assert_preq!(args[1], Term::Number(Num(2.0, None)));
         assert_eq!(parser.cursor, 5);
     }
+
+    #[test]
+    fn parse_parses_empty_list() {
+        let tokens = lex(b"[]").unwrap();
+        let mut parser = Parser::new(&tokens);
+        let term = parser.parse_term().unwrap();
+        let list = Term::List(List(Vec::new()));
+        assert_preq!(term, list);
+        assert_eq!(parser.cursor, 2);
+    }
+
+    #[test]
+    fn parse_parses_singleton_list() {
+        let one = Term::Number(Num(1.0, None));
+        let list = Term::List(List(vec![one]));
+
+        // Without trailing semicolon.
+        let tokens = lex(b"[1]").unwrap();
+        let mut parser = Parser::new(&tokens);
+        let term = parser.parse_term().unwrap();
+        assert_preq!(term, list);
+        assert_eq!(parser.cursor, 3);
+
+        // With trailing semicolon.
+        let tokens = lex(b"[1;]").unwrap();
+        let mut parser = Parser::new(&tokens);
+        let term = parser.parse_term().unwrap();
+        assert_preq!(term, list);
+        assert_eq!(parser.cursor, 4);
+    }
+
+    #[test]
+    fn parse_parses_list_with_two_elements() {
+        let one = Term::Number(Num(1.0, None));
+        let two = Term::Number(Num(2.0, None));
+        let list = Term::List(List(vec![one, two]));
+
+        // Without trailing semicolon.
+        let tokens = lex(b"[1; 2]").unwrap();
+        let mut parser = Parser::new(&tokens);
+        let term = parser.parse_term().unwrap();
+        assert_preq!(term, list);
+        assert_eq!(parser.cursor, 5);
+
+        // With trailing semicolon.
+        let tokens = lex(b"[1; 2;]").unwrap();
+        let mut parser = Parser::new(&tokens);
+        let term = parser.parse_term().unwrap();
+        assert_preq!(term, list);
+        assert_eq!(parser.cursor, 6);
+    }
+
+    #[test]
+    fn parse_fails_on_empty_list_with_semicolon() {
+        let tokens = lex(b"[;]").unwrap();
+        let mut parser = Parser::new(&tokens);
+        let result = parser.parse_term();
+        assert_eq!(result.err().unwrap().token_index, 1);
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -529,16 +529,22 @@ impl<'t, 'a: 't> Parser<'t, 'a> {
 
             // After the element, either we immediately close the list with a
             // bracket, or there is a separator and more may follow.
-            match self.take() {
-                Some(Token::RBracket) => return Ok(List(elements)),
-                Some(Token::Semicolon) => continue,
+            match self.peek() {
+                Some(Token::RBracket) => {
+                    self.consume();
+                    return Ok(List(elements));
+                }
+                Some(Token::Semicolon) => {
+                    self.consume();
+                    continue;
+                }
                 Some(Token::Comma) => {
                     // Trying to use a comma as list separator is likely going
                     // to be a common mistake, as it is common from other
                     // languages. (Perhaps I should use comma after all for that
                     // reason.) Add a hint about that.
                     let msg = "Parse error in list: expected ';' or ']'. \
-                               Note: rather than ',' use ';' to separate elements.";
+                               Note: use ';' to separate elements.";
                     return self.error(msg)
                }
                 _ => {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -228,6 +228,7 @@ impl<'a> Env<'a> {
         bindings.insert(names::font_family, Val::Str("sans".to_string()));
         bindings.insert(names::font_style, Val::Str("roman".to_string()));
         bindings.insert(names::fill_circle, Val::FnIntrin(Builtin(builtins::fill_circle)));
+        bindings.insert(names::fill_polygon, Val::FnIntrin(Builtin(builtins::fill_polygon)));
         bindings.insert(names::fill_rectangle, Val::FnIntrin(Builtin(builtins::fill_rectangle)));
         bindings.insert(names::text_align, Val::Str("left".to_string()));
         bindings.insert(names::line_height, Val::Num(128.0, 1));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -28,6 +28,7 @@ pub enum Val<'a> {
     Str(String),
     Col(Color),
     Coord(f64, f64, LenDim),
+    List(Vec<Val<'a>>),
     Frame(Rc<Frame<'a>>),
     FnExtrin(&'a FnDef<'a>),
     FnIntrin(Builtin),
@@ -86,6 +87,7 @@ impl<'a> Val<'a> {
             Val::Str(..) => ValType::Str,
             Val::Col(..) => ValType::Color,
             Val::Coord(_, _, d) => ValType::Coord(d),
+            Val::List(..) => ValType::List,
             Val::Frame(..) => ValType::Frame,
             Val::FnExtrin(..) => ValType::Fn,
             Val::FnIntrin(..) => ValType::Fn,
@@ -462,6 +464,14 @@ impl<'a> Print for Val<'a> {
                 f.print(col.b);
                 f.print(") : color");
             }
+            Val::List(ref elements) => {
+                f.print("[");
+                for element in elements {
+                    f.print(element);
+                    f.print("; ");
+                }
+                f.print("]");
+            }
             Val::Coord(x, y, d) => {
                 f.print("(");
                 f.print(x);
@@ -490,6 +500,7 @@ impl Print for ValType {
             ValType::Str => f.print("str"),
             ValType::Color => f.print("color"),
             ValType::Coord(d) => { f.print("coord of "); print_unit(f, d); }
+            ValType::List => f.print("list"),
             ValType::Frame => f.print("frame"),
             ValType::Fn => f.print("function"),
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,6 +11,8 @@ pub enum ValType {
     Str,
     Color,
     Coord(LenDim),
+    // TODO: Make list homogeneous, and carry an element type?
+    List,
     Frame,
     Fn
 }


### PR DESCRIPTION
* Make the lexer consume `[`, `;`, `]`.
* Make the parser construct list terms.
* Add list values to the runtime.
* Evaluate lists in the interpreter.
* Add a `fill_polygon` builtin that takes a list of coords of len.